### PR TITLE
add config for LED override

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
 | **Option 1: Automatic Discovery (Recommended)** | 1. Go to **Settings** → **Devices & Services** → **Integrations**<br>2. Click **+ Add Integration**<br>3. Search for **"FlashForge"**<br>4. Select your printer from the discovered list<br>5. Enter your printer's **Check Code**<br>6. Click **Submit** |
 | **Option 2: Manual Configuration** | 1. Go to **Settings** → **Devices & Services** → **Integrations**<br>2. Click **+ Add Integration**<br>3. Search for **"FlashForge"**<br>4. Select **"Configure Manually"**<br>5. Enter:<br>&nbsp;&nbsp;&nbsp;• **IP Address**: Your printer's IP (e.g., `192.168.1.100`)<br>&nbsp;&nbsp;&nbsp;• **Printer Name**: Friendly name (optional)<br>&nbsp;&nbsp;&nbsp;• **Serial Number**: From printer settings<br>&nbsp;&nbsp;&nbsp;• **Check Code**: From LAN mode settings<br>6. Click **Submit** |
 | **Configuration Options** | After setup, you can adjust settings:<br><br>1. Go to **Settings** → **Devices & Services** → **FlashForge**<br>2. Click **⋮** on your printer → **Configure**<br>3. **Scan Interval**: Update frequency in seconds (5-300, default: 10) |
+| **LED Switch Override** | If your printer's LED switch is not detected but you know it is supported, enable **Always show LED switch** in the options. This will force the LED switch to appear regardless of printer capability checks. |
 
 </div>
 

--- a/custom_components/flashforge/__init__.py
+++ b/custom_components/flashforge/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_CHECK_CODE,
     CONF_SCAN_INTERVAL,
     CONF_SERIAL_NUMBER,
+    CONF_OVERRIDE_LED_AVAILABILITY,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -41,6 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     check_code = entry.data[CONF_CHECK_CODE]
     name = entry.data.get(CONF_NAME, "FlashForge Printer")
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    override_led_availability = entry.options.get(CONF_OVERRIDE_LED_AVAILABILITY, False)
 
     # Create FlashForge client
     client = FlashForgeClient(
@@ -71,6 +73,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Error validating printer credentials: %s", err)
         await async_close_flashforge_client(client)
         raise ConfigEntryNotReady(f"Error validating printer credentials: {err}") from err
+
+    # This should be a configuration option in the library directly, but for now we set it here
+    if override_led_availability:
+        client.led_control = True
 
     # Create coordinator
     coordinator = FlashForgeDataUpdateCoordinator(

--- a/custom_components/flashforge/config_flow.py
+++ b/custom_components/flashforge/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     DEFAULT_NAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    CONF_OVERRIDE_LED_AVAILABILITY,
 )
 from .util import async_close_flashforge_client
 
@@ -281,15 +282,15 @@ class FlashForgeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> FlashForgeOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return FlashForgeOptionsFlowHandler(config_entry)
+        return FlashForgeOptionsFlowHandler()
 
 
 class FlashForgeOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for FlashForge integration."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._conf_app_id: str | None = None
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -308,6 +309,10 @@ class FlashForgeOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=5, max=300)),
+                    vol.Optional(
+                        CONF_OVERRIDE_LED_AVAILABILITY,
+                        default=self.config_entry.options.get(CONF_OVERRIDE_LED_AVAILABILITY, False),
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/flashforge/const.py
+++ b/custom_components/flashforge/const.py
@@ -6,6 +6,7 @@ DOMAIN = "flashforge"
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_CHECK_CODE = "check_code"
 CONF_SCAN_INTERVAL = "scan_interval"
+CONF_OVERRIDE_LED_AVAILABILITY = "override_led_availability"
 
 # Default values
 DEFAULT_NAME = "FlashForge Printer"

--- a/custom_components/flashforge/strings.json
+++ b/custom_components/flashforge/strings.json
@@ -53,7 +53,8 @@
         "title": "FlashForge Options",
         "description": "Configure options for your FlashForge printer",
         "data": {
-          "scan_interval": "Update Interval (seconds)"
+          "scan_interval": "Update Interval (seconds)",
+          "override_led_availability": "Always show LED switch (override printer capability check)"
         }
       }
     }

--- a/custom_components/flashforge/translations/en.json
+++ b/custom_components/flashforge/translations/en.json
@@ -53,7 +53,8 @@
         "title": "FlashForge Options",
         "description": "Configure options for your FlashForge printer",
         "data": {
-          "scan_interval": "Update Interval (seconds)"
+          "scan_interval": "Update Interval (seconds)",
+          "override_led_availability": "Always show LED switch (override printer capability check)"
         }
       }
     }


### PR DESCRIPTION
adds a manual override for the LED switch. 
fixes #5 

This also updates the unsupported config flow for HA 2025.12: https://developers.home-assistant.io/blog/2024/11/12/options-flow/